### PR TITLE
Chapter storybook fixes

### DIFF
--- a/src/components/Buttons/Button/Button.vue
+++ b/src/components/Buttons/Button/Button.vue
@@ -171,6 +171,7 @@ export default {
   margin: 5px;
   white-space: nowrap;
   position: relative;
+  cursor: pointer;
 
   &:disabled {
     cursor: not-allowed;

--- a/src/components/DataVisualization/Card/Card.stories.mdx
+++ b/src/components/DataVisualization/Card/Card.stories.mdx
@@ -48,7 +48,7 @@ export const Template = (args, { argTypes}) => ({
         :height="height"
       >
         <template #background>
-          Content Background
+          <p class="pb">Content Background</p>
         </template>
         <template #expansive-footer>
           <span style="color: var(--color-white) !important;">


### PR DESCRIPTION
Storybook fixes from [this chapter activity](https://www.notion.so/adapcon/Atividades-afa9f320f0b24a96accb2a1d1580f78f?p=ca8c27ffd6f44d8ea40836048737bbfc)

* add cursor: pointer to PbButton: Storybook doesn't use default browser styles, making the hover work on other projects but no on Storybook itself.
![image](https://user-images.githubusercontent.com/43160711/149779904-d219907d-79d3-4cc3-ab9b-ef683472e748.png)
* wrap the background example text in PbCard in a p tag so that the font family doesn't look out of place
![image](https://user-images.githubusercontent.com/43160711/149780275-6ab53aa3-09b6-40cc-ae20-ec842a9dc77f.png)
