### PR TITLE
fix: make drag and drop container relative to page

### DIFF
--- a/src/components/Layout/DragAndDrop/DragAndDrop.vue
+++ b/src/components/Layout/DragAndDrop/DragAndDrop.vue
@@ -145,6 +145,7 @@ export default {
   gap: 20px;
   padding: 20px;
   box-sizing: border-box;
+  position: relative;
 
   .item {
     display: flex;


### PR DESCRIPTION
Position `absolute` in the drag and drop handle causes the items to be positioned relative to the viewport, causing weird behaviors when the container overflows. Adding `position: relative` to the container fixes the issue.