### PR TITLE
feat: add background light button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/src/components/Buttons/Button/Button.stories.mdx
+++ b/src/components/Buttons/Button/Button.stories.mdx
@@ -19,7 +19,7 @@ import { colors } from '@pb/utils/constants.js';
     buttonStyle: {
       control: {
         type: 'select',
-        options: ['regular', 'background', 'outline'],
+        options: ['regular', 'background', 'outline', 'background-light'],
       },
       defaultValue: 'regular',
     },

--- a/src/components/Buttons/Button/Button.stories.mdx
+++ b/src/components/Buttons/Button/Button.stories.mdx
@@ -128,6 +128,18 @@ In this example we use the primary color:
   </Story>
 </Canvas>
 
+### Background-light Color
+
+As same for background, but the background will be an 8% opacity from the color, and the text will be 100%.
+This property accepts our standard colors (primary, secondary, success, danger, warning, and info).
+In this example we use the primary color:
+
+<Canvas>
+  <Story name="Background-light" height="auto" args={{ buttonStyle: 'background-light' }} >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
 ### Notification Badge
 
 At certain times it is necessary to inform some type of notification to the user,

--- a/src/components/Buttons/Button/Button.vue
+++ b/src/components/Buttons/Button/Button.vue
@@ -129,7 +129,8 @@ export default {
         ? `var(--color-${this.color})`
         : 'var(--color-primary)';
 
-      const color = getComputedStyle(document.documentElement).getPropertyValue(`--color-${this.color || 'primary'}`);
+      const color = getComputedStyle(document.documentElement).getPropertyValue(`--color-${this.color}`);
+      const hexadecimalOpacity = '14'; // 8%
 
       switch (this.buttonStyle) {
         case 'outline':
@@ -137,7 +138,7 @@ export default {
         case 'background':
           return `background-color: ${colorVar}; color: ${this.color === 'white' ? 'var(--color-primary)' : 'white'};`;
         case 'background-light':
-          return `background-color: ${color}14;  color: ${colorVar};`;
+          return `background-color: ${color}${hexadecimalOpacity};  color: ${colorVar};`;
         default:
           return `color: ${colorVar}`;
       }

--- a/src/components/Buttons/Button/Button.vue
+++ b/src/components/Buttons/Button/Button.vue
@@ -129,11 +129,15 @@ export default {
         ? `var(--color-${this.color})`
         : 'var(--color-primary)';
 
+      const color = getComputedStyle(document.documentElement).getPropertyValue(`--color-${this.color || 'primary'}`);
+
       switch (this.buttonStyle) {
         case 'outline':
           return `border-color: ${colorVar}; color: ${colorVar}`;
         case 'background':
           return `background-color: ${colorVar}; color: ${this.color === 'white' ? 'var(--color-primary)' : 'white'};`;
+        case 'background-light':
+          return `background-color: ${color}14;  color: ${colorVar};`;
         default:
           return `color: ${colorVar}`;
       }


### PR DESCRIPTION
This PR I creating a new background light button style.

I Bring this solution with @caroltrindade to get the hexa value of a prop, to concat the opacity only for background
I put 8%(the hexa value is 14) to the background color.. (this was Validated with @brunaboeger )

Primary
![image](https://user-images.githubusercontent.com/62998447/167642744-68d76e87-3a5b-4bf5-98fc-d6e9e003076e.png)
Primary Light
![image](https://user-images.githubusercontent.com/62998447/167643095-f9bb845f-e4b0-4e89-8b8f-cf70d95984d8.png)


Warning
![image](https://user-images.githubusercontent.com/62998447/167642879-5d5e8b44-1da0-4130-8b5d-7124782e77ae.png)
Warning Light
![image](https://user-images.githubusercontent.com/62998447/167642956-f27e774a-2071-4020-895d-9bced743cb4a.png)
