### PR TITLE
chore: remove unused globals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,15 +59,6 @@ module.exports = {
       },
     },
   },
-  globals: {
-    Atomics: 'readonly',
-    SharedArrayBuffer: 'readonly',
-    brain: 'writable',
-    $: true,
-    moment: true,
-    swal: true,
-    _: true,
-  },
   plugins: [
     'vue',
   ],


### PR DESCRIPTION
remove unused globals variables in eslint