### PR TITLE
feat: added property to show hint only in overflow

### DIFF
--- a/src/components/Miscellaneous/Hint/Hint.stories.mdx
+++ b/src/components/Miscellaneous/Hint/Hint.stories.mdx
@@ -26,6 +26,10 @@ import { colors } from '@pb/utils/constants.js';
     disabled: {
       type: 'boolean',
       defaultValue: false,
+    },
+    showOnOverflowOnly: {
+      type: 'boolean',
+      defaultValue: false,
     }
   }}
 />
@@ -39,6 +43,7 @@ export const Template = (args, { argTypes }) => ({
       :color="color"
       :hint-text="hintText"
       :disabled="disabled"
+      :show-on-overflow-only="showOnOverflowOnly"
     >
       Hover me
     </PbHint>
@@ -58,6 +63,37 @@ export const TemplateSlot = (args, { argTypes }) => ({
         <h1 class="pb">Hello</h1>
       </template>
     </PbHint>
+  `,
+});
+
+export const TemplateOnOverflowOnly = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { PbHint },
+  template: `
+    <div>
+      <PbHint
+        :position="position"
+        :color="color"
+        :hint-text="hintText"
+        :disabled="disabled"
+        :show-on-overflow-only="showOnOverflowOnly"
+      >
+        <p style="width: 125px; white-space: nowrap;  overflow: hidden; text-overflow: ellipsis;">
+          I'm overflowed, here
+        </p>
+      </PbHint>
+      <PbHint
+        :position="position"
+        :color="color"
+        :hint-text="hintText"
+        :disabled="disabled"
+        :show-on-overflow-only="showOnOverflowOnly"
+      >
+        <p style="width: 125px; white-space: nowrap;  overflow: hidden; text-overflow: ellipsis;">
+          I'm not overflowed
+        </p>
+      </PbHint>
+    </div>
   `,
 });
 
@@ -83,5 +119,13 @@ The component itself is in charge of controlling the display of the hint when ho
 <Canvas>
   <Story name="Slot" height="auto" parameters={{ layout: 'centered' }}>
     {TemplateSlot.bind({})}
+  </Story>
+</Canvas>
+
+### On Overflow Only
+
+<Canvas>
+  <Story name="On Overflow Only" height="auto" parameters={{ layout: 'centered' }} args={{ showOnOverflowOnly: true, position: 'top-right' }}>
+    {TemplateOnOverflowOnly.bind({})}
   </Story>
 </Canvas>

--- a/src/components/Miscellaneous/Hint/Hint.vue
+++ b/src/components/Miscellaneous/Hint/Hint.vue
@@ -2,8 +2,8 @@
   <div class="pb-hint-container">
     <div
       class="pb-hint-slot"
-      @mouseenter="state.showHint = true"
-      @mouseleave="state.showHint = false"
+      @mouseenter="showHint(true)"
+      @mouseleave="showHint(false)"
     >
       <slot />
     </div>
@@ -24,6 +24,7 @@
 <script>
 export default {
   name: 'PbHint',
+
   props: {
     position: {
       type: String,
@@ -38,13 +39,30 @@ export default {
     color: { type: String, default: 'primary' },
     hintText: { type: [String, Number], default: '' },
     disabled: { type: Boolean, default: false },
+    showOnOverflowOnly: { type: Boolean, default: false },
   },
+
   data() {
     return {
       state: {
         showHint: false,
       },
     };
+  },
+  
+  methods: {
+    showHint(value) {
+      if (this.showOnOverflowOnly) {
+        const element = this.$slots.default[0].elm;
+  
+        if (element.scrollWidth > element.clientWidth || element.scrollHeight > element.clientHeight)
+          this.$set(this.state, 'showHint', value);
+        
+        return;
+      }
+
+      this.$set(this.state, 'showHint', value);
+    },
   },
 };
 </script>


### PR DESCRIPTION
### Description

I added a new property to show hint only when its content overflows.
I use this in PbTable component.

PS. I didn't change the package version because I will open other PRs and they will all go together in a single version.

### Screenshots
Storybook:
![storybook](https://user-images.githubusercontent.com/32417804/167822008-2b96f3f3-ade9-4699-a165-724a5298f33b.gif)

In PbTable:
![pbTable](https://user-images.githubusercontent.com/32417804/167822708-208b894f-7863-4af7-a149-28952ca2c25c.gif)

