### PR TITLE
feat: added property to wrap content

### DIFF
--- a/src/components/Miscellaneous/Badge/Badge.stories.mdx
+++ b/src/components/Miscellaneous/Badge/Badge.stories.mdx
@@ -22,6 +22,10 @@ import { colors } from '@pb/utils/constants.js';
     control: { type: 'select', options: [ ...colors ] },
     defaultValue: 'white',
   },
+  wrapContent: {
+    type: 'boolean',
+    defaultValue: false,
+  },
  }}
 />
 
@@ -34,6 +38,7 @@ export const Template = (args, { argTypes }) => ({
       :title="title"
       :background-color="backgroundColor"
       :color="color"
+      :wrap-content="wrapContent"
     />
   `
 });
@@ -51,6 +56,14 @@ This component was created to highlight the relevant text for the user on the sc
 
 <Canvas>
   <Story name="Default">
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+### Wrap Content
+
+<Canvas>
+  <Story name="Wrap Content" args={{ wrapContent: true }}>
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/src/components/Miscellaneous/Badge/Badge.vue
+++ b/src/components/Miscellaneous/Badge/Badge.vue
@@ -33,14 +33,20 @@ export default {
       default: 'white',
       validator: color => validateColor(color),
     },
+    wrapContent: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   computed: {
     style() {
       const backgroundColorIsHexColor = isHexColor(this.backgroundColor);
+      
       return `
         background: ${backgroundColorIsHexColor ? this.backgroundColor : `var(--color-${this.backgroundColor})`} !important;
         color: var(--color-${this.color}) !important;
+        display: ${this.wrapContent ? 'inline-block' : ''};
       `;
     },
 


### PR DESCRIPTION
### Description

I added a new property to wrap content in the badge.

PS. I didn't change the package version because I will open other PRs and they will all go together in a single version.

### Screenshot

Default;
![image](https://user-images.githubusercontent.com/32417804/167823736-8d8596b4-6c21-419d-a794-685e41345993.png)

Wrap:
![image](https://user-images.githubusercontent.com/32417804/167823822-c8989688-e626-4a18-8b6b-ff4e0614e6f6.png)
