### PR TITLE
feat: remove muted and background dark

### DIFF
--- a/src/components/Buttons/SortButton/SortButton.vue
+++ b/src/components/Buttons/SortButton/SortButton.vue
@@ -46,7 +46,7 @@ export default {
     buttonColor() {
       return this.value
         ? 'primary'
-        : 'muted';
+        : 'gray-20';
     },
     buttonIcon() {
       return this.value === 'asc'

--- a/src/components/FiltersAndSearch/Find/Find.vue
+++ b/src/components/FiltersAndSearch/Find/Find.vue
@@ -100,7 +100,7 @@ export default {
     background: none;
     outline: none;
     transition: all .3s ease;
-    border: 1px solid var(--color-muted);
+    border: 1px solid var(--color-gray-20);
 
     &:focus {
       border: 1px solid var(--color-primary);

--- a/src/components/FiltersAndSearch/SearchInput/SearchInput.vue
+++ b/src/components/FiltersAndSearch/SearchInput/SearchInput.vue
@@ -109,7 +109,7 @@ export default {
     background: none;
     outline: none;
     transition: all .3s ease;
-    border: 1px solid var(--color-muted);
+    border: 1px solid var(--color-gray-20);
 
     &:focus {
       border: 1px solid var(--color-gray-90);
@@ -189,13 +189,13 @@ export default {
   flex-direction: column;
   font-size: 13px;
   background: #fff;
-  border: 1px solid var(--color-muted);
+  border: 1px solid var(--color-gray-20);
   border-radius: 0 0 20px 20px;
 
   .pb-search-suggestions-item {
     cursor: pointer;
     padding: 6px 20px;
-    color: var(--color-muted);
+    color: var(--color-gray-20);
     transition: all .2s ease;
 
     .pb-search-suggestions-item-icon {

--- a/src/components/Inputs/Checkbox/Checkbox.vue
+++ b/src/components/Inputs/Checkbox/Checkbox.vue
@@ -85,7 +85,7 @@ export default {
 
   methods: {
     getColor(color) {
-      return this.disabled ? 'muted' : color;
+      return this.disabled ? 'gray-20' : color;
     },
   },
 };

--- a/src/components/Inputs/DateInput/DateInput.stories.mdx
+++ b/src/components/Inputs/DateInput/DateInput.stories.mdx
@@ -12,7 +12,7 @@ import { colors } from '@pb/utils/constants.js';
     },
     color: {
       control: { type: 'select', options: [ ...colors ] },
-      defaultValue: 'muted',
+      defaultValue: 'gray-20',
     },
   }}
 />

--- a/src/components/Inputs/DateInput/DateInput.vue
+++ b/src/components/Inputs/DateInput/DateInput.vue
@@ -23,7 +23,7 @@ export default {
     onValidate: { type: Function, default: null },
     color: {
       type: String,
-      default: 'muted',
+      default: 'gray-20',
       validator: color => validateColor(color),
     },
   },

--- a/src/components/Inputs/NumberInput/NumberInput.stories.mdx
+++ b/src/components/Inputs/NumberInput/NumberInput.stories.mdx
@@ -24,7 +24,7 @@ import { colors } from '@pb/utils/constants.js';
     },
     color: {
       control: { type: 'select', options: [ ...colors ] },
-      defaultValue: 'muted',
+      defaultValue: 'gray-20',
     },
     validator: {
       type: 'function',

--- a/src/components/Inputs/NumberInput/NumberInput.vue
+++ b/src/components/Inputs/NumberInput/NumberInput.vue
@@ -33,7 +33,7 @@ export default {
 
     validator: { type: Function, default: null },
 
-    color: { type: String, default: 'muted', validator: validateColor },
+    color: { type: String, default: 'gray-20', validator: validateColor },
 
     focus: { type: Boolean, default: false },
 

--- a/src/components/Inputs/TextArea/TextArea.stories.mdx
+++ b/src/components/Inputs/TextArea/TextArea.stories.mdx
@@ -20,7 +20,7 @@ import { colors } from '@pb/utils/constants.js';
     },
     color: {
       control: { type: 'select', options: [ ...colors ] },
-      defaultValue: 'muted',
+      defaultValue: 'gray-20',
     },
     validator: {
       type: 'function',

--- a/src/components/Inputs/TextArea/TextArea.vue
+++ b/src/components/Inputs/TextArea/TextArea.vue
@@ -32,7 +32,7 @@ export default {
 
     validator: { type: Function, default: null },
 
-    color: { type: String, default: 'muted', validator: validateColor },
+    color: { type: String, default: 'gray-20', validator: validateColor },
 
     focus: { type: Boolean, default: false },
 

--- a/src/components/Inputs/TextInput/TextInput.stories.mdx
+++ b/src/components/Inputs/TextInput/TextInput.stories.mdx
@@ -20,7 +20,7 @@ import { colors } from '@pb/utils/constants.js';
     },
     color: {
       control: { type: 'select', options: [ ...colors ] },
-      defaultValue: 'muted',
+      defaultValue: 'gray-20',
     },
     validator: {
       type: 'function',

--- a/src/components/Inputs/TextInput/TextInput.vue
+++ b/src/components/Inputs/TextInput/TextInput.vue
@@ -31,7 +31,7 @@ export default {
 
     validator: { type: Function, default: null },
 
-    color: { type: String, default: 'muted', validator: validateColor },
+    color: { type: String, default: 'gray-20', validator: validateColor },
 
     focus: { type: Boolean, default: false },
   },

--- a/src/components/Inputs/ThreeStateCheckbox/ThreeStateCheckbox.vue
+++ b/src/components/Inputs/ThreeStateCheckbox/ThreeStateCheckbox.vue
@@ -107,7 +107,7 @@ export default {
     },
 
     getColor(color) {
-      return this.disabled ? 'muted' : color;
+      return this.disabled ? 'gray-20' : color;
     },
   },
 };

--- a/src/components/Miscellaneous/Fieldset/Fieldset.stories.mdx
+++ b/src/components/Miscellaneous/Fieldset/Fieldset.stories.mdx
@@ -15,7 +15,7 @@ import { colors } from '@pb/utils/constants.js';
         type: 'select',
         options: [ ...colors ],
       },
-      defaultValue: 'muted',
+      defaultValue: 'gray-20',
     },
   }}
 />

--- a/src/components/Miscellaneous/FooterNavigation/FooterNavigation.vue
+++ b/src/components/Miscellaneous/FooterNavigation/FooterNavigation.vue
@@ -118,7 +118,7 @@ export default {
   width: 100vw;
   bottom: 0;
   position: fixed;
-  background-color: var(--color-background-dark);
+  background-color: var(--color-gray-60);
 
   .liveshop-footer-navigation-actions {
     display: flex;

--- a/src/components/NotificationsAndModals/Alert/Alert.stories.mdx
+++ b/src/components/NotificationsAndModals/Alert/Alert.stories.mdx
@@ -27,7 +27,7 @@ import PbButton from '@pb/Buttons/Button/Button.vue';
       defaultValue: '600px',
     },
     buttonColor: {
-      control: { type: 'select', options: ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'muted'] },
+      control: { type: 'select', options: ['primary', 'secondary', 'success', 'danger', 'warning', 'info'] },
       defaultValue: 'warning',
     },
   }}

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -26,9 +26,7 @@
 
   /** Other colors */
   --color-active: #0011ff;
-  --color-muted: #aaa;
   --color-overlay: rgba(0, 0, 0, .5);
-  --color-background-dark: #484F59;
 }
 
 /* roboto-300 - latin */

--- a/src/components/utils/constants.js
+++ b/src/components/utils/constants.js
@@ -6,7 +6,7 @@ export const colors = [
   'danger',
   'warning',
   'info',
-  'muted',
+  'notification',
   'white',
   'gray',
   'gray-10',
@@ -15,5 +15,4 @@ export const colors = [
   'gray-60',
   'gray-80',
   'gray-90',
-  'background-dark',
 ];

--- a/src/components/variables.scss
+++ b/src/components/variables.scss
@@ -16,7 +16,6 @@ $colors: (
   "danger",
   "warning",
   "info",
-  "muted",
   "white",
   "gray",
   "gray-10",
@@ -25,5 +24,4 @@ $colors: (
   "gray-60",
   "gray-80",
   "gray-90",
-  'background-dark',
 );


### PR DESCRIPTION
@brunaboeger requested to remove the colors `background-dark` and `muted`, it will be not used anymore.

I changed from `background-dark` to `gray-60` and from `muted` to `gray-20`.