### PR TITLE
feat: added Pb Table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/src/components/DataVisualization/Table/Table.stories.mdx
+++ b/src/components/DataVisualization/Table/Table.stories.mdx
@@ -1,0 +1,214 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+
+import PbTable from './Table.vue';
+import PbButton from '../../Buttons/Button/Button.vue';
+
+<Meta
+  title = "Components/Data Visualization/PbTable"
+  component = { PbTable }
+  argTypes = {{
+    header: {
+      type: 'array',
+      defaultValue: [
+        { label: 'Nome', size: 3, priority: 1 },
+        { label: 'Idade', size: 1, priority: 3 },
+        { label: 'Banco Principal', size: 2, priority: 2 },
+      ],
+    },
+    rows: {
+      type: 'array',
+      defaultValue: [
+        [
+          { value: 'João Paulo de Ávila Alfredo', secondaryValue: '123.456.789-10' },
+          { value: '20' },
+          { value: 'https://s3-sa-east-1.amazonaws.com/adapcon-pro-production-customer/script-financeiro/bacen-237.png' },
+        ],
+        [
+          { value: 'Maria da Silva', secondaryValue: '661.313.649-23' },
+          { value: '22', },
+          { value: 'https://s3-sa-east-1.amazonaws.com/adapcon-pro-production-customer/script-financeiro/bacen-341.png' },
+        ],
+        [
+          { value: 'Lucca Gael Ferreira', secondaryValue: '898.372.281-30' },
+          { value: '16', },
+          { value: 'Não informado', badges: ['menor de idade'] },
+        ],
+        [
+          { value: 'Sofia Jennifer Gomes da Silva Mendes de Souza', secondaryValue: '398.722.811-30' },
+          { value: '23', },
+          { value: 'Sem preferência' },
+        ],
+        [
+          { value: 'Mário Oliveira', secondaryValue: '898.372.281-30' },
+          { value: '11', },
+          { value: 'Não informado', badges: ['menor de idade', '< 12'] },
+        ],
+      ],
+    },
+    metadata: {
+      type: 'array',
+      defaultValue: [
+        { name: 'João Paulo de Ávila', cpf: '12345678910', driverLicense: true },
+        { name: 'Maria da Silva', cpf: '66131364923', driverLicense: true },
+        { name: 'Lucca Gael Ferreira', cpf: '89837228130', driverLicense: false },
+        { name: 'Sofia Jennifer Gomes da Silva Mendes de Souza', cpf: '39872281130', driverLicense: true },
+        { name: 'Mário Oliveira', cpf: '89837228130', driverLicense: false }
+      ],
+    },
+    loading: { type: 'boolean', defaultValue: false },
+    ellipsisOnOverflow: { type: 'boolean', defaultValue: true },
+    highlightOnHover: { type: 'boolean', defaultValue: true },
+    hasActionColumn: { type: 'boolean', defaultValue: true },
+    hasSort: { type: 'boolean', defaultValue: true },
+    hasSearch: { type: 'boolean', defaultValue: true },
+    maxHeight: { type: 'string', defaultValue: '' },
+    actionsSize: { type: 'string', defaultValue: '1' },
+  }}
+/>
+
+export const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { PbTable, PbButton },
+  template: `
+    <div style="background-color: white;">
+      <PbTable
+        :header="header"
+        :rows="rows"
+        :metadata="metadata"
+        :loading="loading"
+        :ellipsis-on-overflow="ellipsisOnOverflow"
+        :highlight-on-hover="highlightOnHover"
+        :has-action-column="hasActionColumn"
+        :has-sort="hasSort"
+        :has-search="hasSearch"
+        :max-height="maxHeight"
+        :actions-size="actionsSize"
+      >
+        <template #actions="{ row, metadata }">
+          <div style="display: flex;">
+            <PbButton
+              icon="fas fa-star"
+              button-style="regular"
+            />
+            <PbButton
+              v-if="row[2].badges && row[2].badges.find(badge => badge === '< 12')"
+              icon="fas fa-info-circle"
+              button-style="regular"
+            />
+            <PbButton
+              v-if="metadata.driverLicense"
+              icon="fas fa-image"
+              button-style="regular"
+            />
+          </div>
+        </template>
+      </PbTable>
+    </div>
+  `,
+});
+
+export const TemplateWithoutActions = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { PbTable },
+  template: `
+    <div style="background-color: white;">
+      <PbTable
+        :header="header"
+        :rows="rows"
+        :metadata="metadata"
+        :loading="loading"
+        :ellipsis-on-overflow="ellipsisOnOverflow"
+        :highlight-on-hover="highlightOnHover"
+        :has-action-column="hasActionColumn"
+        :has-sort="hasSort"
+        :has-search="hasSearch"
+        :max-height="maxHeight"
+        :actions-size="actionsSize"
+      />  
+    </div>
+  `,
+});
+
+export const TemplateWithExtraActions = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { PbTable, PbButton },
+  template: `
+    <div style="background-color: white;">
+      <PbTable
+        :header="header"
+        :rows="rows"
+        :metadata="metadata"
+        :loading="loading"
+        :ellipsis-on-overflow="ellipsisOnOverflow"
+        :highlight-on-hover="highlightOnHover"
+        :has-action-column="hasActionColumn"
+        :has-sort="hasSort"
+        :has-search="hasSearch"
+        :max-height="maxHeight"
+        :actions-size="actionsSize"
+      >
+        <template #extra-actions>
+          <PbButton
+            label="Baixar CSV"
+            button-style="background"
+          />
+        </template>
+      </PbTable>
+    </div>
+  `,
+});
+
+# **PbFooterNavigation Component**
+### The `PbFooterNavigation` component is used to navigate between pages.
+
+### Purpose and Use case
+
+The footer navigation component receives an array of steps, that is, the screen views.
+Having the possibility to change the button label.
+
+## Configuration
+
+### Properties
+
+| Property                    | Type        | Default     | Description                                                                                   |
+|:----------------------------|:------------|:------------|:----------------------------------------------------------------------------------------------|
+| views                       | Array       |             | List of views                                                                                 |
+| finalButtonLabel            | String      | Fechar      | Title of the final button                                                                     |
+| finalButtonDisabled         | Boolean     | false       | Disable the final button                                                                      |
+| showFirstBackButton         | Boolean     | false       | Shows the first back button, when the component is initialized                                |
+| metadata                    | Array       |             | Its a optional property. It can contains metadata about rows, so should have the same number of rows. It is available in actions slot |
+
+### Events
+
+| Event                       | Type        | Emitter                            | Description                                                                                   |
+|:----------------------------|:------------|:-----------------------------------|:----------------------------------------------------------------------------------------------|
+| changeView                  | String      | Click to next or previous view     | Emits the view to change                                                                      |
+
+
+## Examples
+
+### Default
+
+<Canvas>
+  <Story name="Default" height="auto">
+    { Template.bind({}) }
+  </Story>
+</Canvas>
+
+
+### Without Actions
+
+<Canvas>
+  <Story name="Without Actions" height="auto" args={{ hasActionColumn: false }}>
+    { TemplateWithoutActions.bind({}) }
+  </Story>
+</Canvas>
+
+### With Extra Actions
+
+<Canvas>
+  <Story name="With Extra Actions" height="auto">
+    { TemplateWithExtraActions.bind({}) }
+  </Story>
+</Canvas>
+

--- a/src/components/DataVisualization/Table/Table.stories.mdx
+++ b/src/components/DataVisualization/Table/Table.stories.mdx
@@ -10,7 +10,7 @@ import PbButton from '../../Buttons/Button/Button.vue';
     header: {
       type: 'array',
       defaultValue: [
-        { label: 'Nome', size: 3, priority: 1 },
+        { label: 'Nome', size: 2, priority: 1 },
         { label: 'Idade', size: 1, priority: 3 },
         { label: 'Banco Principal', size: 2, priority: 2 },
       ],
@@ -60,9 +60,9 @@ import PbButton from '../../Buttons/Button/Button.vue';
     highlightOnHover: { type: 'boolean', defaultValue: true },
     hasActionColumn: { type: 'boolean', defaultValue: true },
     hasSort: { type: 'boolean', defaultValue: true },
-    hasSearch: { type: 'boolean', defaultValue: true },
+    hasActionsBar: { type: 'boolean', defaultValue: true },
     maxHeight: { type: 'string', defaultValue: '' },
-    actionsSize: { type: 'string', defaultValue: '1' },
+    actionsSize: { type: 'number', defaultValue: 1 },
   }}
 />
 
@@ -80,7 +80,7 @@ export const Template = (args, { argTypes }) => ({
         :highlight-on-hover="highlightOnHover"
         :has-action-column="hasActionColumn"
         :has-sort="hasSort"
-        :has-search="hasSearch"
+        :has-actions-bar="hasActionsBar"
         :max-height="maxHeight"
         :actions-size="actionsSize"
       >
@@ -121,7 +121,7 @@ export const TemplateWithoutActions = (args, { argTypes }) => ({
         :highlight-on-hover="highlightOnHover"
         :has-action-column="hasActionColumn"
         :has-sort="hasSort"
-        :has-search="hasSearch"
+        :has-actions-bar="hasActionsBar"
         :max-height="maxHeight"
         :actions-size="actionsSize"
       />  
@@ -143,7 +143,7 @@ export const TemplateWithExtraActions = (args, { argTypes }) => ({
         :highlight-on-hover="highlightOnHover"
         :has-action-column="hasActionColumn"
         :has-sort="hasSort"
-        :has-search="hasSearch"
+        :has-actions-bar="hasActionsBar"
         :max-height="maxHeight"
         :actions-size="actionsSize"
       >
@@ -158,31 +158,63 @@ export const TemplateWithExtraActions = (args, { argTypes }) => ({
   `,
 });
 
-# **PbFooterNavigation Component**
-### The `PbFooterNavigation` component is used to navigate between pages.
+# **PbTable Component**
+### The `PbTable` component is used to display data.
 
 ### Purpose and Use case
 
-The footer navigation component receives an array of steps, that is, the screen views.
-Having the possibility to change the button label.
+The table receives a header array and rows array and display the data.
 
 ## Configuration
 
+### Header
+
+List wiht one object to each column of table.
+
+| Property                    | Type                   | Default | Description                                                                                   |
+|:----------------------------|:-----------------------|:--------|:----------------------------------------------------------------------------------------------|
+| label                       | String, Number         |         | The column label                                                                              |
+| size                        | Number                 |         | The size of column. The table uses the 12 column grid bootstrap system                        |
+| priority                    | Number                 |         | The priority of column. It is used to hide column  when occurs a overflow.                    |
+
+### Rows
+
+List of arrays to each row, containing one object to each column of table;
+
+| Property                    | Type                   | Default | Description                                                                                   |
+|:----------------------------|:-----------------------|:--------|:----------------------------------------------------------------------------------------------|
+| value                       | String, Number, Image  |         | The column value                                                                              |
+| secondaryValue              | String, Number         |         | A extra info to column (Optional).                                                            |
+| badges                      | String, Number         |         | A list of badges to column (Optional).                                                        |
+
+
 ### Properties
 
-| Property                    | Type        | Default     | Description                                                                                   |
-|:----------------------------|:------------|:------------|:----------------------------------------------------------------------------------------------|
-| views                       | Array       |             | List of views                                                                                 |
-| finalButtonLabel            | String      | Fechar      | Title of the final button                                                                     |
-| finalButtonDisabled         | Boolean     | false       | Disable the final button                                                                      |
-| showFirstBackButton         | Boolean     | false       | Shows the first back button, when the component is initialized                                |
-| metadata                    | Array       |             | Its a optional property. It can contains metadata about rows, so should have the same number of rows. It is available in actions slot |
+| Property                    | Type        | Default | Description                                                                                              |
+|:----------------------------|:------------|:--------|:---------------------------------------------------------------------------------------------------------|
+| metadata                    | Array       |         | A list of metadata about each row in table. It is available in actions slot (Optional).                  |
+| loading                     | Boolean     | false   | Indicates that data is being loaded and when true a loading bar is displayed.                            |
+| ellipsisOnOverflow          | Boolean     | true    | Shows ellipsis on overflow and display the rest of the information in a hint.                            |
+| highlightOnHover            | Boolean     | true    | Highlights the row on hover.                                                                             |
+| hasActionColumn             | Boolean     | true    | Shows the action column. When activated you can use the actions slot to put actions inside.              |
+| hasSort                     | Boolean     | true    | Allows sorting in columns.                                                                               |
+| hasActionsBar               | Boolean     | true    | Shows the actions bar, with a search input and a extra-actions slot.                                     |
+| maxHeight                   | String      |         | Sets a maximumn height to table. Should have the unit of measure.                                        |
+| actionsSize                 | Number      | 1       | Sets the size of actions column,                                                                         |
 
 ### Events
 
-| Event                       | Type        | Emitter                            | Description                                                                                   |
-|:----------------------------|:------------|:-----------------------------------|:----------------------------------------------------------------------------------------------|
-| changeView                  | String      | Click to next or previous view     | Emits the view to change                                                                      |
+| Event                       | Type        | Emitter                            | Description                                                                   |
+|:----------------------------|:------------|:-----------------------------------|:------------------------------------------------------------------------------|
+| search                      | String      | Input data in searchinput          | Emits the search term                                                         |
+| clear-input                 |             | Clean the search input             | Emits that search input has been cleared                                      |
+
+### Slots
+
+| Name                       | Props           | Description                                                                                                                                |
+|:---------------------------|:----------------|:-------------------------------------------------------------------------------------------------------------------------------------------|
+| actions                    | row, metadata   | This slot is displayed in actions column. It available two properties: row (the columns objects) and metadata (the wor metadata).          |
+| extra-actions              |                 | This slot is displayed on the right side of the search input.                                                                              |
 
 
 ## Examples

--- a/src/components/DataVisualization/Table/Table.stories.mdx
+++ b/src/components/DataVisualization/Table/Table.stories.mdx
@@ -159,11 +159,11 @@ export const TemplateWithExtraActions = (args, { argTypes }) => ({
 });
 
 # **PbTable Component**
-### The `PbTable` component is used to display data.
+### The `PbTable` component is a table used to display data.
 
 ### Purpose and Use case
 
-The table receives a header array and rows array and display the data.
+The table is usually used in pages to list content.
 
 ## Configuration
 

--- a/src/components/DataVisualization/Table/Table.vue
+++ b/src/components/DataVisualization/Table/Table.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="table-container">
-    <div :class="{ 'actions-bar': !isMobile, 'actions-bar-mobile': isMobile }">
+    <div
+      v-if="hasActionsBar"
+      :class="{ 'actions-bar': !isMobile, 'actions-bar-mobile': isMobile }"
+    >
       <div class="search-input">
         <PbSearchInput
           v-model="state.searchTerm"
@@ -70,9 +73,9 @@ export default {
     highlightOnHover: { type: Boolean, default: true },
     hasActionColumn: { type: Boolean, default: true },
     hasSort: { type: Boolean, default: true },
-    hasSearch: { type: Boolean, default: true },
+    hasActionsBar: { type: Boolean, default: true },
     maxHeight: { type: String, default: '' },
-    actionsSize: { type: String, default: '1' },
+    actionsSize: { type: Number, default: 1 },
   },
 
   data() {
@@ -103,6 +106,7 @@ export default {
     
     calculatedMaxHeight() {
       if (!this.maxHeight) return;
+      if (!this.hasActionsBar) return this.maxHeight;
 
       const actionsBarHeight = 50;
       const actionsBarMarginBottom = this.isMobile ? 24 : 40;

--- a/src/components/DataVisualization/Table/Table.vue
+++ b/src/components/DataVisualization/Table/Table.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="table-container">
+    <div :class="{ 'actions-bar': !isMobile, 'actions-bar-mobile': isMobile }">
+      <div class="search-input">
+        <PbSearchInput
+          v-model="state.searchTerm"
+          placeholder="O que você procura?"
+          @search="$emit('search', state.searchTerm)"
+          @clear-input="$emit('clear-input')"
+        />
+      </div>
+      
+      <slot name="extra-actions" />
+    </div>
+
+    <TableHeader
+      :header="header"
+      :ellipsis-on-overflow="ellipsisOnOverflow"
+      :has-action-column="hasActionColumn"
+      :has-sort="hasSort"
+      :actions-size="actionsSize"
+      @sort="activeSorting => state.activeSorting = activeSorting"
+    />
+
+    <PbLoadingBar v-if="loading" />
+
+    <TableRows
+      :header="header"
+      :rows="sortedRows"
+      :metadata="metadata"
+      :ellipsis-on-overflow="ellipsisOnOverflow"
+      :highlight-on-hover="highlightOnHover"
+      :has-action-column="hasActionColumn"
+      :max-height="calculatedMaxHeight"
+      :actions-size="actionsSize"
+    >
+      <template #actions="props">
+        <slot
+          name="actions"
+          :row="props.row"
+          :metadata="props.metadata"
+        />
+      </template>
+    </TableRows>
+  </div>
+</template>
+
+<script>
+import TableHeader from './TableHeader.vue';
+import TableRows from './TableRows.vue';
+import PbSearchInput from '../../FiltersAndSearch/SearchInput/SearchInput.vue';
+import PbLoadingBar from '../../Loadings/LoadingBar/LoadingBar.vue';
+
+export default {
+  name: 'PbTable',
+
+  components: {
+    TableHeader,
+    TableRows,
+    PbSearchInput,
+    PbLoadingBar,
+  },
+
+  props: {
+    header: { type: Array, default: () => [] },
+    rows: { type: Array, default: () => [] },
+    metadata: { type: Array, default: () => [] },
+    loading: { type: Boolean, default: false },
+    ellipsisOnOverflow: { type: Boolean, default: true },
+    highlightOnHover: { type: Boolean, default: true },
+    hasActionColumn: { type: Boolean, default: true },
+    hasSort: { type: Boolean, default: true },
+    hasSearch: { type: Boolean, default: true },
+    maxHeight: { type: String, default: '' },
+    actionsSize: { type: String, default: '1' },
+  },
+
+  data() {
+    return {
+      windowWidth: window.innerWidth,
+      state: {
+        isMobile: window.innerWidth <= 375,
+        activeSorting: {},
+        searchTerm: '',
+      },
+    };
+  },
+
+  computed: {
+    isMobile() {
+      return this.windowWidth <= 375;
+    },
+
+    sortedRows() {
+      const rows = [...this.rows];
+
+      if (!Object.keys(this.state.activeSorting).length) return rows;
+
+      const { columnIndex, type } = this.state.activeSorting;
+
+      return rows.sort((current, next) => this.sort(current[columnIndex], next[columnIndex], type));
+    },
+    
+    calculatedMaxHeight() {
+      if (!this.maxHeight) return;
+
+      const actionsBarHeight = 50;
+      const actionsBarMarginBottom = this.isMobile ? 24 : 40;
+
+      return `calc(${this.maxHeight} - ${actionsBarHeight}px - ${actionsBarMarginBottom}px)`;
+    },
+  },
+
+  mounted() {
+    window.addEventListener('resize', this.setWindowWidth);
+  },
+
+  beforeDestroy() {
+    window.removeEventListener('resize', this.setWindowWidth);
+  },
+
+  methods: {
+    setWindowWidth({ target } = {}) {
+      if (!target) return;
+
+      this.windowWidth = target.innerWidth;
+    },
+
+    sort(current, next, type) {
+      const currentValue = current.value || '';
+      const nextValue = next.value || '';
+
+      if (type === 'desc') return currentValue < nextValue ? 1 : -1;
+      if (type === 'asc') return currentValue > nextValue ? 1 : -1;
+
+      return 0;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.table-container {
+  .actions-bar {
+    display: flex;
+    align-items: center;
+    margin-bottom: 40px;
+
+    .search-input {
+      margin-right: 24px;
+      width: 100%;
+    }
+  }
+
+  .actions-bar-mobile {
+    display: flex;
+    align-items: center;
+    margin-bottom: 24px;
+
+    .search-input {
+      margin-right: 16px;
+      width: 100%;
+    }
+  }
+}
+</style>

--- a/src/components/DataVisualization/Table/TableHeader.vue
+++ b/src/components/DataVisualization/Table/TableHeader.vue
@@ -42,7 +42,7 @@ export default {
     ellipsisOnOverflow: { type: Boolean, default: true },
     hasActionColumn: { type: Boolean, default: true },
     hasSort: { type: Boolean, default: true },
-    actionsSize: { type: String, default: '1' },
+    actionsSize: { type: Number, default: 1 },
   },
 
   data() {

--- a/src/components/DataVisualization/Table/TableHeader.vue
+++ b/src/components/DataVisualization/Table/TableHeader.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="table-header-container pb-row">
+    <div
+      v-for="(column, index) in header"
+      :key="column.label"
+      :class="`pb-col-${column.size} table-column`"
+    >
+      <small class="pb">{{ column.label }}</small>
+
+      <PbSortIcon
+        v-if="hasSort"
+        :value="getSortType(index)"
+        color="gray-90"
+        class="sort-icon"
+        @input="type => setSortState(type, index)"
+      />
+    </div>
+
+    <div
+      v-if="hasActionColumn"
+      :class="`pb-col-${actionsSize} table-column`"
+    >
+      <small class="pb">AÇÕES</small>
+    </div>
+  </div>
+</template>
+
+<script>
+import PbSortIcon from '../../Miscellaneous/SortIcon/SortIcon.vue';
+import PbHint from '../../Miscellaneous/Hint/Hint.vue';
+
+export default {
+  name: 'TableHeader',
+
+  components: {
+    PbSortIcon,
+    PbHint,
+  },
+
+  props: {
+    header: { type: Array, default: () => [] },
+    ellipsisOnOverflow: { type: Boolean, default: true },
+    hasActionColumn: { type: Boolean, default: true },
+    hasSort: { type: Boolean, default: true },
+    actionsSize: { type: String, default: '1' },
+  },
+
+  data() {
+    return {
+      state: {
+        sorts: [],
+      },
+    };
+  },
+
+  methods: {
+    getSortType(columnIndex) {
+      return this.state.sorts[columnIndex] ? this.state.sorts[columnIndex].type : '';
+    },
+
+    setSortState(type, columnIndex) {
+      if (!this.state.sorts[columnIndex]) this.$set(this.state.sorts, [columnIndex], {});
+
+      this.$set(this.state.sorts[columnIndex], 'type', type);
+      this.clearSortState(columnIndex);
+      
+      this.$emit('sort', { columnIndex, type });
+    },
+
+    clearSortState(selectedSort) {
+      return Object.keys(this.state.sorts).forEach(columnIndex => {
+        if (Number(columnIndex) !== Number(selectedSort))
+          this.$set(this.state.sorts[columnIndex], 'type', '');
+      });
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.table-header-container {
+  background-color: var(--color-gray);
+  
+  .table-column {
+    display: flex;
+    padding: 8px;
+
+    small {
+      text-transform: uppercase;
+    }
+
+    .sort-icon {
+      margin-left: 8px;
+      font-size: 13px;
+    }
+  }
+}
+</style>

--- a/src/components/DataVisualization/Table/TableRows.vue
+++ b/src/components/DataVisualization/Table/TableRows.vue
@@ -1,0 +1,126 @@
+<template>
+  <div
+    class="table-rows pb-scroll-primary"
+    :style="`${maxHeight ? `max-height: ${maxHeight}` : ''}`"
+  >
+    <div
+      v-for="(row, index) in rows"
+      :key="index"
+      :class="{ 'row-highlight': highlightOnHover }"
+    >
+      <div class="table-row pb-row">
+        <div
+          v-for="(column, columnIndex) in row"
+          :key="columnIndex"
+          :class="`pb-col-${header[columnIndex].size} table-column`"
+        >
+          <img
+            v-if="isImage(column.value)"
+            :src="column.value"
+            class="image"
+          >
+
+          <div v-else>
+            <PbHint
+              :hint-text="column.value"
+              :disabled="!ellipsisOnOverflow"
+              :show-on-overflow-only="true"
+              position="bottom-right"
+            >
+              <p :class="`${ellipsisOnOverflow ? 'pb-md ellipsis-on-overflow' : 'pb-md'}`">{{ column.value }}</p>
+            </PbHint>
+
+            <p class="pb-sm secondary-value">{{ column.secondaryValue }}</p>
+          </div>
+
+          <div>
+            <PbBadge
+              v-for="badge of column.badges"
+              :key="badge"
+              :title="badge"
+              :wrap-content="true"
+              style="margin-right: 2px;"
+            />
+          </div>
+        </div>
+
+        <div
+          v-if="hasActionColumn"
+          :class="`pb-col-${actionsSize} column`"
+        >
+          <slot
+            name="actions"
+            :row="row"
+            :metadata="metadata[index]"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import PbHint from '../../Miscellaneous/Hint/Hint.vue';
+import PbBadge from '../../Miscellaneous/Badge/Badge.vue';
+import { isImage } from 'adapcon-utils-js';
+
+export default {
+  name: 'TableRows',
+
+  components: {
+    PbHint,
+    PbBadge,
+  },
+
+  props: {
+    header: { type: Array, default: () => [] },
+    rows: { type: Array, default: () => [] },
+    metadata: { type: Array, default: () => [] },
+    ellipsisOnOverflow: { type: Boolean, default: true },
+    highlightOnHover: { type: Boolean, default: true },
+    hasActionColumn: { type: Boolean, default: true },
+    maxHeight: { type: String, default: '' },
+    actionsSize: { type: String, default: '1' },
+  },
+
+  methods: {
+    isImage,
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.table-rows {
+  overflow: auto;
+  
+  .row-highlight > :hover {
+    background-color: var(--color-gray);
+    transition: 0.5s;
+  }
+
+  .table-row {
+    display: flex;
+
+    .table-column {
+      padding: 8px;
+
+      .ellipsis-on-overflow {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .image {
+        height: 24px;
+        width: 24px;
+      }
+
+      .secondary-value {
+        color: var(--color-gray-40);
+        margin-top: 8px !important;
+      }
+    }
+  }
+
+}
+</style>

--- a/src/components/DataVisualization/Table/TableRows.vue
+++ b/src/components/DataVisualization/Table/TableRows.vue
@@ -80,7 +80,7 @@ export default {
     highlightOnHover: { type: Boolean, default: true },
     hasActionColumn: { type: Boolean, default: true },
     maxHeight: { type: String, default: '' },
-    actionsSize: { type: String, default: '1' },
+    actionsSize: { type: Number, default: 1 },
   },
 
   methods: {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -38,6 +38,7 @@ export { default as PbProgressBar } from './DataVisualization/ProgressBar/Progre
 export { default as PbRanking } from './DataVisualization/Ranking/Ranking.vue';
 export { default as PbServerTable } from './DataVisualization/ServerTable/ServerTable.vue';
 export { default as PbSummaryDisplayItem } from './DataVisualization/SummaryDisplayItem/SummaryDisplayItem.vue';
+export { default as PbTable } from './DataVisualization/Table/Table.vue';
 export { default as PbCard } from './DataVisualization/Card/Card.vue';
 export { default as PbCarousel } from './DataVisualization/Carousel/Carousel.vue';
 export { default as PbDataTable } from './DataVisualization/DataTable/DataTable.vue';


### PR DESCRIPTION
### Description

I create the Pb Table component. It was developed and validated with @brunaboeger 

PS. Search input overflows window width in the storybook, I can't fix that. When I use the component on another page the problem does not occur, only in storybook

### Screenshots
![table](https://user-images.githubusercontent.com/32417804/167900730-78764331-6c35-47df-91a0-ef9b517789c5.gif)

With extra actions
![image](https://user-images.githubusercontent.com/32417804/167901015-0f680a91-4c0e-4e14-b180-1afda87c7efd.png)

Use case
![image](https://user-images.githubusercontent.com/32417804/167904798-319a5859-df2d-44b1-bb26-27cdd74eedd3.png)

Use case with metadata:
In the new Financial module, I need to show a button only if the document has an external bearer (isExternalBearer) but this information is not displayed in the table, so I pass it in the metadata to the PbTable and use the metadata of each row to validate which button I will show.
![image](https://user-images.githubusercontent.com/32417804/167929745-a0a5725b-f3f4-46cd-8048-25be41774f2f.png)
![image](https://user-images.githubusercontent.com/32417804/167930190-e897fac6-ae2c-4ce7-88f6-4a60a9eb95e0.png)

