### PR TITLE
fix: show scroll when it has to many components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "0.7.1",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "0.7.1",
+  "version": "0.8.1",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/src/components/Miscellaneous/FormBuilder/FormDrawer.vue
+++ b/src/components/Miscellaneous/FormBuilder/FormDrawer.vue
@@ -350,6 +350,7 @@ export default {
 
     .form-drawer-main-content {
       overflow: auto;
+      max-height: 70vh;
     }
 
     .form-drawer-footer {


### PR DESCRIPTION
QA Review found a bug that even if there were too many components on screen the scroll wasn't shown.