### PR TITLE
Fix/layout grid and tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/src/components/Layout/LayoutGrid/LayoutGrid.vue
+++ b/src/components/Layout/LayoutGrid/LayoutGrid.vue
@@ -6,10 +6,10 @@
           <div class="pb-col-12 pb-col-md-10">
             <div class="sidebar-area">
               <PbButton
-                v-if="!state.isMobileCell"
-                style="margin-top: 10px;"
+                v-if="!state.isMobileCell && !state.isMobileTablet"
                 color="primary"
                 button-style="regular"
+                class="back-button"
                 icon="fas fa-arrow-up fa-rotate-270"
                 @click.native="backFunction"
               />
@@ -94,13 +94,19 @@ export default {
 
 <style lang="scss" scoped>
 .layout-grid-container {
+  padding-top: 28px;
+  
   .sidebar {
     border-right: solid #eeeeee 1px;
-    margin: 28px 0px 40px;
+    margin: 0px 0px 40px;
 
     .sidebar-area {
       display: flex;
       align-items: flex-start;
+
+      .back-button {
+        margin-top: 0px;
+      }
     }
 
     .sidebar-content {
@@ -110,7 +116,6 @@ export default {
 
   .tool-bar {
     height: 40px;
-    margin-top: 28px;
   }
 
   .main {

--- a/src/components/Miscellaneous/Tabs/Tabs.vue
+++ b/src/components/Miscellaneous/Tabs/Tabs.vue
@@ -49,13 +49,13 @@
                     v-if="!showOnlyIcon"
                     :class="{ 'abbreviatedText': abbreviatedText }"
                   >
-                    <b
+                    <p
                       v-if="!state.editTab"
-                      class="pb selected-tab"
+                      class="pb-strong selected-tab"
                       :style="`color: var(--color-${color});`"
                     >
                       {{ tabSettings.label }}
-                    </b>
+                    </p>
                     <input
                       v-if="state.editTab"
                       v-focus
@@ -97,11 +97,11 @@
                     v-if="!showOnlyIcon"
                     :class="{ 'abbreviatedText': abbreviatedText }"
                   >
-                    <b
-                      class="pb"
+                    <p
+                      class="pb-strong"
                     >
                       {{ tabSettings.label }}
-                    </b>
+                    </p>
                   </div>
                 </div>
                 <p


### PR DESCRIPTION
### Description

I adjusted the layout grid to don't show the back button in the tablet version.
Also, adjusts the tag of tab label to <p>.
It was requested by @brunaboeger 

### Screenshots

![image](https://user-images.githubusercontent.com/32417804/171200583-2dd620bb-2741-4d7c-a292-20fd85580ede.png)
![image](https://user-images.githubusercontent.com/32417804/171200832-7aa91a82-dcab-4054-8d16-96dbb79dd8d9.png)

