### PR TITLE
fix: corrected field formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/src/components/Inputs/TaxIdInput/TaxIdInput.vue
+++ b/src/components/Inputs/TaxIdInput/TaxIdInput.vue
@@ -86,9 +86,7 @@ export default {
 
     taxIdInput: {
       get() {
-        return this.state.inputValue.length <= 11
-          ? this.stringToCpfFormat(this.state.inputValue)
-          : this.stringToCnpjFormat(this.state.inputValue);
+        return this.formatValue(this.state.inputValue);
       },
 
       set(document) {
@@ -120,21 +118,24 @@ export default {
   },
 
   methods: {
-    stringToCnpjFormat(cnpj) {
-      cnpj = cnpj.replace(/\D/g, '');
-      cnpj = cnpj.replace(/^(\d{2})(\d)/, '$1.$2');
-      cnpj = cnpj.replace(/^(\d{2})\.(\d{3})(\d)/, '$1.$2.$3');
-      cnpj = cnpj.replace(/\.(\d{3})(\d)/, '.$1/$2');
-      cnpj = cnpj.replace(/(\d{4})(\d)/, '$1-$2');
-      return cnpj;
-    },
+    formatValue(value) {
+      let documentTypesBylength = {};
 
-    stringToCpfFormat(cpf) {
-      cpf = cpf.replace(/\D/g, '');
-      cpf = cpf.replace(/(\d{3})(\d)/, '$1.$2');
-      cpf = cpf.replace(/(\d{3})(\d)/, '$1.$2');
-      cpf = cpf.replace(/(\d{3})(\d{1,2})$/, '$1-$2');
-      return cpf;
+      this.allowedDocuments.forEach(documentType => {
+        const { length } = documentTypesData[documentType];
+
+        if (length < value.length) return;
+
+        documentTypesBylength = {
+          ...documentTypesBylength,
+          [length]: [documentType],
+        };
+      });
+
+      const minimumnLength = Math.min(...Object.keys(documentTypesBylength));
+      const documentType = documentTypesBylength[minimumnLength];
+
+      return documentTypesData[documentType].format(value);
     },
 
     validateLength(documentToValidate) {

--- a/src/components/Inputs/TaxIdInput/documentTypes.js
+++ b/src/components/Inputs/TaxIdInput/documentTypes.js
@@ -3,10 +3,25 @@ export const documentTypesData = {
     placeholder: '___.___.___-__',
     length: 11,
     formattedLength: 14,
+    format(value) {
+      let valueFormatted = value.replace(/\D/g, '');
+      valueFormatted = valueFormatted.replace(/(\d{3})(\d)/, '$1.$2');
+      valueFormatted = valueFormatted.replace(/(\d{3})(\d)/, '$1.$2');
+      valueFormatted = valueFormatted.replace(/(\d{3})(\d{1,2})$/, '$1-$2');
+      return valueFormatted;
+    }
   },
   cnpj: {
     placeholder: '__.___.___/____-__',
     length: 14,
     formattedLength: 18,
+    format(value) {
+      let valueFormatted = value.replace(/\D/g, '');
+      valueFormatted = valueFormatted.replace(/^(\d{2})(\d)/, '$1.$2');
+      valueFormatted = valueFormatted.replace(/^(\d{2})\.(\d{3})(\d)/, '$1.$2.$3');
+      valueFormatted = valueFormatted.replace(/\.(\d{3})(\d)/, '.$1/$2');
+      valueFormatted = valueFormatted.replace(/(\d{4})(\d)/, '$1-$2');
+      return valueFormatted;
+    },
   },
 };


### PR DESCRIPTION
### Description

Adjusted component to format value according the allowed documents.
Before my change, if you use this component passing ['cnpj'] as allowedDocuments, the component was formatting the value as CPF first and then as CNPJ.

### Screenshots

Now if you pass ['cnpj'] as allowedDocuments the component will format the value only as CNPJ:
![image](https://user-images.githubusercontent.com/32417804/220297896-a1a3e11c-7704-4d13-bd3b-35c979ba8f0d.png)
