### PR TITLE
Feat: adjusting pbEmptyState

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/src/components/Miscellaneous/EmptyState/EmptyState.vue
+++ b/src/components/Miscellaneous/EmptyState/EmptyState.vue
@@ -36,7 +36,7 @@ export default {
   align-items: center;
 
   .text-info {
-      margin-top: 30px !important;
+      margin-top: 16px !important;
       color: var(--color-gray-40)
   }
 }


### PR DESCRIPTION
### Description

Adjusting PbEmptyState to look like the prototype.

Just adjusting the margin-top size of the text class.

### Screenshots

Before: 

![image](https://user-images.githubusercontent.com/82161592/227389827-58cddb0b-2912-4b24-9965-d5cba7a505fc.png)

After:

![image](https://user-images.githubusercontent.com/82161592/227389905-77903716-ab26-4798-abf5-dded44a68659.png)


