### PR TITLE
Fix: remove conversation to File of base64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/src/components/Inputs/AudioInput/AudioInput.vue
+++ b/src/components/Inputs/AudioInput/AudioInput.vue
@@ -86,7 +86,7 @@ export default {
     mimeType: {
       type: String,
       default: 'audio/mpeg',
-      validator: value => ['audio/mpeg', 'audio/ogg', 'audio/ogg; codecs=opus', 'audio/wav', 'audio/amr', 'audio/acc'].includes(value),
+      validator: value => ['audio/mpeg', 'audio/ogg', 'audio/ogg; codecs=opus', 'audio/wav', 'audio/amr', 'audio/aac'].includes(value),
     },
   },
 
@@ -245,7 +245,7 @@ export default {
         reader.readAsDataURL(blob);
         reader.onload = () => {
           this.setupAudio(reader.result);
-          this.$emit('audio', new File([reader.result], 'audio', { type: this.mimeType }));
+          this.$emit('audio', reader.result);
           resolve();
         };
         reader.onerror = reject;


### PR DESCRIPTION
### Description
reader.result already has the base64 of the audio file. So, now, we emit it to the parent component and remove the conversion from the parent.

