### PR TITLE
[Fix] Adjusted resetDates function on DateRangePicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/src/components/Inputs/DateRangePicker/DateRangePicker.stories.mdx
+++ b/src/components/Inputs/DateRangePicker/DateRangePicker.stories.mdx
@@ -10,6 +10,10 @@ import { colors } from '@pb/utils/constants.js';
       type: 'Object',
       defaultValue: { startDate: '', endDate: '' },
     },
+    initialValue: {
+      type: 'Object',
+      defaultValue: { startDate: '', endDate: '' },
+    },
     calendarsPosition: {
       type: 'String',
       defaultValue: 'right',
@@ -37,6 +41,7 @@ export const Template = (args, { argTypes}) => ({
     <PbDateRangePicker
       style="width: 265px;"
       v-model="value"
+      :initial-value="initialValue"
       :calendars-position="calendarsPosition"
       :input-style="inputStyle"
     />

--- a/src/components/Inputs/DateRangePicker/DateRangePicker.vue
+++ b/src/components/Inputs/DateRangePicker/DateRangePicker.vue
@@ -276,6 +276,10 @@ export default {
 
   props: {
     value: { type: Object, default: () => {} },
+    initialValue: {
+      type: Object,
+      default: () => ({ startDate: '', endDate: '' }),
+    },
     calendarsPosition: { type: String, default: 'right' },
     inputStyle: { type: String, default: 'background-light' },
   },
@@ -557,7 +561,7 @@ export default {
     },
 
     resetDates() {
-      this.selectPeriod('Hoje');
+      Object.assign(this.state.inputValue, this.initialValue);
     },
 
     saveDates() {


### PR DESCRIPTION
### Description

adjusted conditions to reset the date to an initial value passed by props or the default that have no dates

### Screenshots

![reset-dates-range-picker](https://github.com/Adapcon/vue-polar-bear/assets/80467897/b8b6b71b-7c53-492c-ab66-45cba2235224)
