### PR TITLE
Feat/Fix - Can delete and start new recording properly and audio duration is consistent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "2.3.11",
+  "version": "2.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "2.3.11",
+  "version": "2.3.12",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/src/components/Inputs/AudioInput/AudioInput.stories.mdx
+++ b/src/components/Inputs/AudioInput/AudioInput.stories.mdx
@@ -39,7 +39,7 @@ It emits the audio in base64 format every time the user finish or pause the audi
 | Event                       | Description
 |:----------------------------|:---------------------------------------------------------------------
 | change-state                | emit whenever the audio changes from recording to paused and paused to recording
-| audio                       | emit a object containing the audio blob whenever the audio buffer is created (when recording is paused) and the audio duration in seconds ({ data: audioBlob, duration: audioDuration })
+| audio                       | emit an object containing the audio blob whenever the audio buffer is created (when recording is paused) and the audio duration in seconds ({ data: audioBlob, duration: audioDuration })
 
 
 ## Examples

--- a/src/components/Inputs/AudioInput/AudioInput.stories.mdx
+++ b/src/components/Inputs/AudioInput/AudioInput.stories.mdx
@@ -38,8 +38,8 @@ It emits the audio in base64 format every time the user finish or pause the audi
 
 | Event                       | Description
 |:----------------------------|:---------------------------------------------------------------------
-| changeState                 | emit whenever the audio changes from recording to paused and paused to recording
-| audio                       | emit a base64 string whenever the audio buffer is created (when recording is paused)
+| change-state                | emit whenever the audio changes from recording to paused and paused to recording
+| audio                       | emit a object containing the audio blob whenever the audio buffer is created (when recording is paused) and the audio duration in seconds ({ data: audioBlob, duration: audioDuration })
 
 
 ## Examples

--- a/src/components/Inputs/AudioInput/AudioInput.vue
+++ b/src/components/Inputs/AudioInput/AudioInput.vue
@@ -121,9 +121,7 @@ export default {
     },
 
     duration() {
-      return this.audio.element?.duration !== Infinity && !!this.audio.element?.duration
-        ? this.audio.element?.duration
-        : this.audio.duration;
+      return this.audio.duration;
     },
 
     formattedDuration() {
@@ -366,9 +364,10 @@ export default {
        .ball {
         position: absolute;
         cursor: pointer;
-        top: -2px;
+        top: -4px;
         height: 7px;
         width: 7px;
+        padding: 2px;
         border-radius: 50%;
         background-color: var(--color-primary);
       }

--- a/src/components/Inputs/AudioInput/AudioInput.vue
+++ b/src/components/Inputs/AudioInput/AudioInput.vue
@@ -14,6 +14,7 @@
             :icon="playerIcon"
             size="fa-xs"
             class="pb-audio-player-icon"
+            :disabled="audio.duration === 0"
             @click.native="togglePlay"
           />
         </div>
@@ -128,8 +129,8 @@ export default {
     formattedDuration() {
       const minutes = this.duration > 60 ? Math.floor(this.duration / 60) : 0;
       const seconds = this.duration > 60
-        ? String(Math.floor(this.duration - minutes * 60)).padStart(2, '0')
-        : String(Math.floor(this.duration)).padStart(2, '0');
+        ? String(Math.ceil(this.duration - minutes * 60)).padStart(2, '0')
+        : String(Math.ceil(this.duration)).padStart(2, '0');
 
       return `${minutes}:${seconds}`;
     },
@@ -184,6 +185,8 @@ export default {
     },
 
     clearAudio() {
+      clearInterval(this.audio.interval);
+
       this.audio = {
         chunks: [],
         recorded: null,
@@ -196,6 +199,9 @@ export default {
         isPlaying: false,
         interval: null,
       };
+
+      if (this.mediaRecorder)
+        this.mediaRecorder.stop();
     },
 
     toggleRecorder() {
@@ -242,7 +248,7 @@ export default {
 
       this.setupAudio(URL.createObjectURL(blob));
 
-      this.$emit('audio', blob);
+      this.$emit('audio', { data: blob, duration: this.audio.duration });
     },
 
     togglePlay() {


### PR DESCRIPTION
### Description
Changing how the clearAudio method works and how we handle pause and stop on recording so the user can delete and start new recording properly. Change how duration gets through computeds so it is consistent.
I am also making the drag ball bigger to make it easy to go back and forth on the audio timeline.
