### PR TITLE
[Feat] clear audio tracks after stop record

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "2.3.13",
+  "version": "2.3.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "2.3.13",
+  "version": "2.3.14",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/src/components/Inputs/AudioInput/AudioInput.vue
+++ b/src/components/Inputs/AudioInput/AudioInput.vue
@@ -224,6 +224,10 @@ export default {
             this.audio.chunks.push(e.data);
           };
 
+          this.mediaRecorder.onstop = () => {
+            stream.getTracks().forEach(track => track.stop());
+          };
+
           this.mediaRecorder.start(1);
         });
     },


### PR DESCRIPTION
### Description
Clear/Stop audio tracks after mediaRecorder stops so the red ball on the app tab is removed when the audio is not being recorded 
