### PR TITLE
feat: receive MediaStream as prop and use it to instantiate MediaRecorder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/src/components/Inputs/AudioInput/AudioInput.stories.mdx
+++ b/src/components/Inputs/AudioInput/AudioInput.stories.mdx
@@ -26,6 +26,9 @@ import { colors } from '@pb/utils/constants.js';
 The `PbAudioInput` component is used to capture audio input from the user.
 It emits the audio in base64 format every time the user finish or pause the audio recordding.
 
+### Important to know
+This component is not "usable" on storybook. The parent component needs to handle the MediaStream creation and browser permission.
+
 
 ### Properties
 
@@ -33,6 +36,7 @@ It emits the audio in base64 format every time the user finish or pause the audi
 |:------------------------|:---------------------|:--------|:-------------------------------
 | recordOnMounted         | Boolean              | false   | if true the audio start to be recorded when mounted
 | mimeType                | String               | audio/mpeg| defines the type that the audio will be recorded
+| stream                  | MediaStream          |         | a MediaStream object that is used to instantiate a MediaRecorder object
 
 ### Events
 

--- a/src/components/Inputs/AudioInput/AudioInput.vue
+++ b/src/components/Inputs/AudioInput/AudioInput.vue
@@ -89,6 +89,10 @@ export default {
       default: 'audio/ogg; codecs=opus',
       validator: value => ['audio/mpeg', 'audio/ogg', 'audio/ogg; codecs=opus', 'audio/wav', 'audio/amr', 'audio/aac'].includes(value),
     },
+    stream: {
+      type: MediaStream,
+      required: true,
+    },
   },
 
   emits: ['change-state', 'audio', 'clear'],
@@ -220,20 +224,17 @@ export default {
 
       this.createDurationInterval();
 
-      navigator.mediaDevices.getUserMedia({ audio: true })
-        .then(stream => {
-          this.mediaRecorder = new MediaRecorder(stream);
+      this.mediaRecorder = new MediaRecorder(this.stream);
 
-          this.mediaRecorder.ondataavailable = e => {
-            this.audio.chunks.push(e.data);
-          };
+      this.mediaRecorder.ondataavailable = e => {
+        this.audio.chunks.push(e.data);
+      };
 
-          this.mediaRecorder.onstop = () => {
-            stream.getTracks().forEach(track => track.stop());
-          };
+      this.mediaRecorder.addEventListener('stop', () => {
+        this.mediaRecorder.stream.getTracks().forEach(track => { track.stop(); });
+      });
 
-          this.mediaRecorder.start(1);
-        });
+      this.mediaRecorder.start(1);
     },
 
     resumeRecord() {
@@ -249,7 +250,6 @@ export default {
 
     stopRecord() {
       this.mediaRecorder?.stop();
-      this.mediaRecorder = null;
     },
 
     formatAudio() {


### PR DESCRIPTION
### Description
This change is needed so we can stop the media tracks properly after stop recording an audio. Instantiating the MediaStream internally blocks the action of `track.stop()` because the component is destroyed before the action is completed.