### PR TITLE
Hover zoom no PbCarousel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "4.3.13",
+  "version": "4.3.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "4.3.13",
+  "version": "4.3.14",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/src/components/DataVisualization/Carousel/Carousel.stories.mdx
+++ b/src/components/DataVisualization/Carousel/Carousel.stories.mdx
@@ -44,7 +44,6 @@ import PbCarousel from './Carousel.vue';
       },
       defaultValue: 'large',
     },
-    clickToZoom: { type: 'boolean', defaultValue: true },
     disable: { type: 'boolean', defaultValue: false },
     disableArrowsOnEdges: { type: 'boolean', defaultValue: false },
     draggingDistance: { type: 'number', defaultValue: 50 },
@@ -75,6 +74,7 @@ import PbCarousel from './Carousel.vue';
     touchable: { type: 'boolean', defaultValue: true },
     transitionSpeed: { type: ['number', 'string'], defaultValue: 600 },
     visibleSlides: { type: 'number', defaultValue: 1 },
+    zoomOnHover: { type: 'boolean', defaultValue: true },
     zoomScale: { type: 'number', defaultValue: 2 },
   }}
 />
@@ -93,7 +93,6 @@ export const Template = (args, { argTypes}) => ({
       :bullets="bullets"
       :bullets-outside="bulletsOutside"
       :carousel-style="carouselStyle"
-      :click-to-zoom="clickToZoom"
       :data="data"
       :disable="disable"
       :disable-arrows-on-edges="disableArrowsOnEdges"
@@ -124,6 +123,7 @@ export const Template = (args, { argTypes}) => ({
       :touchable="touchable"
       :transition-speed="transitionSpeed"
       :visible-slides="visibleSlides"
+      :zoom-on-hover="zoomOnHover"
       :zoom-scale="zoomScale"
       />
     </div>
@@ -183,8 +183,8 @@ You can check the vueper-slides documentation [here.](https://antoniandre.github
 | 3d                      | boolean             | false   | allows you to slide one slide at a time with a 3D effect transition
 | data                    | Object              | { }     | the data you can put in the carousel. You can pass: `title`. `content`, `link`, `openInNew`, `image`, `video`, `duration`
 | carouselStyle           | String              | large   | the size of the component arrows and bullets. ['small', 'medium', 'large']
-| clickToZoom             | Boolean             | false   | allows the image to be zoomed when clicked
-| zoomScale               | Number              | 2       | when clickToZoom is set to true, defines the amount of zoom when clicking on the image
+| zoomOnHover             | Boolean             | false   | allows the image to be zoomed when hovered
+| zoomScale               | Number              | 2       | when zoomOnHover is set to true, defines the amount of zoom when clicking on the image
 
 ### Events
 
@@ -199,6 +199,7 @@ You can check the vueper-slides documentation [here.](https://antoniandre.github
 | autoplay-resume             | fired when autoplay is set to true, and a pause has been triggered either by a mouseover and mouseout or by calling the function resumeAutoplay() via Vue refs
 | image-loaded                | fired when lazy is set to true, and the image succeeded to load.
 | image-failed                | fired when lazy is set to true, and the image failed to load
+| image-click                 | fired when an image is clicked
 
 ## Examples
 

--- a/src/components/DataVisualization/Carousel/Carousel.vue
+++ b/src/components/DataVisualization/Carousel/Carousel.vue
@@ -262,6 +262,7 @@ export default {
     cursor: zoom-in;
     cursor: -webkit-zoom-in;
     cursor: -moz-zoom-in;
+    border-radius: 8px;
 
     .zoom {
       background: white;

--- a/src/components/DataVisualization/Carousel/carousel.scss
+++ b/src/components/DataVisualization/Carousel/carousel.scss
@@ -154,12 +154,12 @@
 .vueperslides--rtl .vueperslides__arrows--outside .vueperslides__arrow--next,
 .vueperslides__arrows--outside .vueperslides__arrow--prev {
   right: auto;
-  left: -3.5em;
+  left: -1.5em;
 }
 .vueperslides--rtl .vueperslides__arrows--outside .vueperslides__arrow--prev,
 .vueperslides__arrows--outside .vueperslides__arrow--next {
   left: auto;
-  right: -3.5em;
+  right: -1.5em;
 }
 .vueperslides__paused {
   top: 0.7em;
@@ -268,9 +268,9 @@
 .vueperslides--fixed-height .vueperslides__parallax-wrapper {
   padding-bottom: 0 !important;
 }
-.vueperslides--fixed-height.vueperslides--bullets-outside {
-  margin-bottom: 4em;
-}
+// .vueperslides--fixed-height.vueperslides--bullets-outside {
+//   margin-bottom: 4em;
+// }
 .vueperslides__inner {
   position: relative;
   -webkit-user-select: none;
@@ -281,6 +281,7 @@
 .vueperslides__parallax-wrapper {
   position: relative;
   overflow: hidden;
+  border-radius: 8px;
 }
 .vueperslides--3d .vueperslides__parallax-wrapper {
   overflow: visible;
@@ -293,6 +294,7 @@
   right: 0;
   overflow: hidden;
   z-index: 1;
+  border-radius: 8px;
 }
 .vueperslides--parallax .vueperslides__track {
   height: 200%;

--- a/src/components/NotificationsAndModals/Dialog/Dialog.vue
+++ b/src/components/NotificationsAndModals/Dialog/Dialog.vue
@@ -88,7 +88,7 @@
 
 <script>
 import PbButton from '@pb/Buttons/Button/Button.vue';
-import PbIcon from '@pb/Miscellaneous/Icon/Icon.js';
+import PbIcon from '@pb/Miscellaneous/Icon/Icon';
 import { validateColor } from '@pb/utils/validator';
 
 export default {
@@ -226,6 +226,8 @@ export default {
     max-height: 100%;
     min-width: 200px;
     z-index: 1;
+    display: flex;
+    flex-direction: column;
 
     .dialog-header {
       padding: 16px 16px 0;
@@ -257,6 +259,9 @@ export default {
 
     .dialog-content {
       padding: 16px;
+      display: flex;
+      flex-direction: column;
+      overflow: auto;
     }
 
     .dialog-footer {


### PR DESCRIPTION
### Description
Foi alterada a prop `clickToZoom` do PbCarousel para `zoomOnHover`. Ao invés de precisar clicar, o zoom vai acontecer quando passar o mouse por cima da imagem. Além disso, foi adicionado um novo evento `image-click` para que seja acionado quando houver um clique na imagem com zoom.

### Obs
Foi necessário adicionar alguns seletores CSS ao PbDialog para corrigir uns erros de imagem extrapolando o container do dialog.