### PR TITLE
Ajusta quebra de linha no componente Hint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/src/components/Miscellaneous/Hint/Hint.vue
+++ b/src/components/Miscellaneous/Hint/Hint.vue
@@ -49,15 +49,15 @@ export default {
       },
     };
   },
-  
+
   methods: {
     showHint(value) {
       if (this.showOnOverflowOnly) {
         const element = this.$slots.default[0].elm;
-  
+
         if (element.scrollWidth > element.clientWidth || element.scrollHeight > element.clientHeight)
           this.$set(this.state, 'showHint', value);
-        
+
         return;
       }
 
@@ -81,8 +81,9 @@ export default {
       color: var(--color-white);
       padding: 9px 20px;
       overflow: hidden;
-      white-space: nowrap;
       border-radius: 20px;
+      width: max-content;
+      white-space: pre-line;
     }
 
     @mixin pb-hint-bottom {


### PR DESCRIPTION
### Description
Conforme a implementação feito no módulo de devolução do repositório simplifica-app, precisou ser ajustado a qubra de linha para que não ultrapassase a tela.

- No cenáriodo problema é listado as transportadoras das notas de devolução

### Card
[ME1-T14](https://projects.zoho.com/portal/plataformasimplificamais#zp/projects/2458384000000079967/tasks/custom-view/2458384000000046003/list/task-detail/2458384000000236019?group_by=tasklist)

### Screenshots
Ajustado com o `\n` (enter):
![image](https://github.com/user-attachments/assets/71dc7ddc-2457-42d9-b1ed-460659517147)

Apenas a string continua a mesma funcionalidade:
![image](https://github.com/user-attachments/assets/e396f3db-1066-4912-a488-8a26cb0355ca)

