### PR TITLE
Adiciona prop dinâmica para valor do timeout no componente de date input

### DIFF
--- a/src/components/Inputs/DateInput/DateInput.stories.mdx
+++ b/src/components/Inputs/DateInput/DateInput.stories.mdx
@@ -10,6 +10,7 @@ import { colors } from '@pb/utils/constants.js';
       type: 'string',
       defaultValue: '',
     },
+    timeOutValue: 1000,
     placeholder: {
       type: 'string',
       defaultValue: '',
@@ -30,6 +31,7 @@ export const Template = (args, { argTypes}) => ({
       :value="value"
       :color="color"
       :placeholder="placeholder"
+      :timeOutValue="timeOutValue"
     />
   `,
 });

--- a/src/components/Inputs/DateInput/DateInput.vue
+++ b/src/components/Inputs/DateInput/DateInput.vue
@@ -26,6 +26,7 @@ export default {
     value: { type: [String, Date], default: '' },
     placeholder: { type: String, default: '' },
     onValidate: { type: Function, default: null },
+    timeOutValue: { type: Number, default: 1000 },
     color: {
       type: String,
       default: 'gray-20',
@@ -73,7 +74,7 @@ export default {
           this.$emit('validation', {
             validation: this.state.validation,
           });
-        }, 1000);
+        }, this.timeOutValue);
       },
     },
 
@@ -111,7 +112,7 @@ export default {
         this.$emit('validation', {
           validation: this.state.validation,
         });
-      }, 1000);
+      }, this.timeOutValue);
       this.state.typeInput = 'date';
     },
 


### PR DESCRIPTION
### Description
Está sendo realizado uma melhoria nos lembretes de pagamento, e conforme verificado, o componenete leva um tempinho para atulizar os dados, com isso ele acaba atribuindo o valor errado.

Foi verificado junto com o Cauã que o componente possui um timeout de 1s.

Foi inserido o valor do timeout como prop para que fosse possível configurar e evitar o delay na atualização da prop.

### Screenshots
**Valor default:**
<img width="510" height="229" alt="image" src="https://github.com/user-attachments/assets/245744df-ffad-4f0c-baae-ca319f20a9b2" />

**Valor inserido com o timeOut em 0:**
<img width="442" height="265" alt="image" src="https://github.com/user-attachments/assets/d2524bd9-e060-4821-a2a5-66bf5b44d288" />

Comparação:
<img width="216" height="55" alt="image" src="https://github.com/user-attachments/assets/c38ae0b5-33a6-4ef1-ab20-1163432e51c7" />
