### PR TITLE
feat: truncate secondaryValue with ellipsis and overflow hint in Table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "4.9.3",
+  "version": "4.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "4.9.3",
+  "version": "4.9.4",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-polar-bear",
-  "version": "4.9.4",
+  "version": "4.10.0",
   "author": "adapcon",
   "scripts": {
     "storybook": "start-storybook --quiet -p 6006 -s ./src/static",

--- a/src/components/DataVisualization/Table/Table.stories.mdx
+++ b/src/components/DataVisualization/Table/Table.stories.mdx
@@ -21,7 +21,7 @@ import PbButton from '../../Buttons/Button/Button.vue';
       type: 'array',
       defaultValue: [
         [
-          { value: 'João Paulo de Ávila Alfredo', secondaryValue: '123.456.789-10' },
+          { value: 'João Paulo de Ávila Alfredo', secondaryValue: 'joao.paulo.de.avila.alfredo@empresa-com-dominio-muito-longo.com.br' },
           { value: '20' },
           { value: ['33.237.930/8965-90', '54.577.985/0001-90'] },
           { value: 'https://s3-sa-east-1.amazonaws.com/adapcon-pro-production-customer/script-financeiro/bacen-237.png' },

--- a/src/components/DataVisualization/Table/TableRows.vue
+++ b/src/components/DataVisualization/Table/TableRows.vue
@@ -90,7 +90,17 @@
                 </p>
               </PbHint>
 
-              <p v-if="column.secondaryValue" class="pb-sm secondary-value">{{ column.secondaryValue }}</p>
+              <PbHint
+                v-if="column.secondaryValue"
+                :hint-text="column.secondaryValue"
+                :disabled="!ellipsisOnOverflow"
+                :show-on-overflow-only="true"
+                position="bottom-right"
+              >
+                <p class="pb-sm secondary-value" :class="{ 'ellipsis-on-overflow': ellipsisOnOverflow }">
+                  {{ column.secondaryValue }}
+                </p>
+              </PbHint>
             </div>
 
             <div
@@ -209,7 +219,17 @@
                   </p>
                 </PbHint>
 
-                <p v-if="column.secondaryValue" class="pb-sm secondary-value">{{ column.secondaryValue }}</p>
+                <PbHint
+                  v-if="column.secondaryValue"
+                  :hint-text="column.secondaryValue"
+                  :disabled="!ellipsisOnOverflow"
+                  :show-on-overflow-only="true"
+                  position="bottom-right"
+                >
+                  <p class="pb-sm secondary-value" :class="{ 'ellipsis-on-overflow': ellipsisOnOverflow }">
+                    {{ column.secondaryValue }}
+                  </p>
+                </PbHint>
               </div>
 
               <div>


### PR DESCRIPTION
### Description

Wrap the secondaryValue paragraph in <PbHint> (main row and expanded row) mirroring the primary value, applying ellipsis-on-overflow conditionally so the pb-sm secondary styling is preserved. Bump to 4.9.4 and update the Table story with a long secondaryValue to demonstrate it.

